### PR TITLE
fix: template using different directories for function file

### DIFF
--- a/webdev/javascript/config.json
+++ b/webdev/javascript/config.json
@@ -1,6 +1,6 @@
 {
     "init": {},
     "build": {
-        "cmd": "npx --package=webpack@5.72.0 --package=webpack-cli@4.9.2 -- webpack --config ./azion/webpack.config.js -o ./dist --mode production"
+        "cmd": "npx --package=webpack@5.72.0 --package=webpack-cli@4.9.2 -- webpack --config ./azion/webpack.config.js -o ./worker --mode production"
     }
 }

--- a/webdev/javascript/webpack.config.js
+++ b/webdev/javascript/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
     target: "webworker",
     entry: "./index.js",
     output: {
-        filename: 'main.js',
+        filename: 'function.js',
         path: path.resolve(__dirname, 'dist'),
       },
     mode: "production",


### PR DESCRIPTION
**WHAT**
Javascript template was using both ./worker and ./dist directories for saving the function file.

**WHY**
[NO ISSUE]