### PR TITLE
feat: add output control to template

### DIFF
--- a/webdev/flareact/README.md
+++ b/webdev/flareact/README.md
@@ -1,0 +1,4 @@
+## output-ctrl options
+
+`on-error` = Displays output only when a error occurs;
+`disable` = Disables output control, thus showing the complete output.

--- a/webdev/flareact/config.json
+++ b/webdev/flareact/config.json
@@ -5,10 +5,12 @@
     },
     "build": {
         "cmd": "npx --yes azion-framework-adapter@0.2.0 build --config ./azion/kv.json || exit $? ;",
-        "env": "./azion/webdev.env"
+        "env": "./azion/webdev.env",
+        "output-ctrl": "on-error"
     },
     "publish": {
         "pre_cmd": "npx --yes azion-framework-adapter@0.2.0 publish -s --config ./azion/kv.json || exit $? ;",
-        "env":"./azion/webdev.env"
+        "env":"./azion/webdev.env",
+        "output-ctrl": "on-error"
     }
 }

--- a/webdev/flareact/config.json
+++ b/webdev/flareact/config.json
@@ -1,7 +1,8 @@
 {
     "init": {
         "cmd": "",
-        "env": ""
+        "env": "",
+        "output-ctrl": "on-error"
     },
     "build": {
         "cmd": "npx --yes azion-framework-adapter@0.2.0 build --config ./azion/kv.json || exit $? ;",

--- a/webdev/javascript/README.md
+++ b/webdev/javascript/README.md
@@ -1,0 +1,4 @@
+## output-ctrl options
+
+`on-error` = Displays output only when a error occurs;
+`disable` = Disables output control, thus showing the complete output.

--- a/webdev/javascript/config.json
+++ b/webdev/javascript/config.json
@@ -1,10 +1,12 @@
 {
     "init": {
         "cmd": "npm install --yes --save-dev clean-webpack-plugin && npm install --yes --save-dev webpack-cli@4.9.2",
-        "env": "./azion/webdev.env"
+        "env": "./azion/webdev.env",
+        "output-ctrl": "on-error"
     },
     "build": {
         "cmd": "npx --yes --package=webpack@5.72.0 --package=webpack-cli@4.9.2 -- webpack --config ./azion/webpack.config.js -o ./worker --mode production || exit $? ;",
-        "env": "./azion/webdev.env"
+        "env": "./azion/webdev.env",
+        "output-ctrl": "on-error"
     }
 }

--- a/webdev/nextjs/README.md
+++ b/webdev/nextjs/README.md
@@ -1,0 +1,4 @@
+## output-ctrl options
+
+`on-error` = Displays output only when a error occurs;
+`disable` = Disables output control, thus showing the complete output.

--- a/webdev/nextjs/config.json
+++ b/webdev/nextjs/config.json
@@ -1,14 +1,17 @@
 {
     "init": {
         "cmd": "./azion/webdev.sh init",
-        "env": ""
+        "env": "",
+        "output-ctrl": "on-error"
     },
     "build": {
         "cmd": "./azion/webdev.sh build",
-        "env": "./azion/webdev.env"
+        "env": "./azion/webdev.env",
+        "output-ctrl": "on-error"
     },
     "publish": {
         "pre_cmd": "./azion/webdev.sh publish",
-        "env":"./azion/webdev.env"
+        "env":"./azion/webdev.env",
+        "output-ctrl": "on-error"
     }
 }


### PR DESCRIPTION
**WHAT**
Add `output-ctrl` field to config.json. This will allow azioncli to either display output in a verbose way or just when an error occurs (default).