### PR TITLE
fix: Include conditional to set variable with openssl-legacy-provider

### DIFF
--- a/webdev/flareact/config.json
+++ b/webdev/flareact/config.json
@@ -9,7 +9,7 @@
         "cmd": "",
         "env": "./azion/webdev.env",
         "output-ctrl": "on-error",
-        "default": "npx --yes azion-framework-adapter@0.2.3 build --config ./azion/kv.json || exit $? ;"
+        "default": "[[ $(node -v |tr -dc '0-9' | cut -c1-2) -gt 16 ]] && OPENSSL_LEGACY=--openssl-legacy-provider; NODE_OPTIONS=$OPENSSL_LEGACY; npx --yes azion-framework-adapter@0.2.3 build --config ./azion/kv.json || exit $? ;"
     },
     "publish": {
         "pre_cmd": "",

--- a/webdev/nextjs/config.json
+++ b/webdev/nextjs/config.json
@@ -9,7 +9,7 @@
         "cmd": "",
         "env": "./azion/webdev.env",
         "output-ctrl": "on-error",
-        "default": "npx next build || exit $? && npx next export || exit $? && npx --yes azion-framework-adapter@0.2.3 build --config ./azion/kv.json -s -d ./out || exit $?"
+        "default": "npx next build || exit $? && npx next export || exit $? && [[ $(node -v |tr -dc '0-9' | cut -c1-2) -gt 16 ]] && OPENSSL_LEGACY=--openssl-legacy-provider; NODE_OPTIONS=$OPENSSL_LEGACY npx --yes azion-framework-adapter@0.2.3 build --config ./azion/kv.json -s -d ./out || exit $?"
     },
     "publish": {
         "pre_cmd": "",


### PR DESCRIPTION
There is a bug on azion-framework-adapter when use webpack 4 to build applications. It use the lib crypto, who use the openssl 1.1.1 and it is no supported by Node 18 anymore, It only support openssl 3.0.
This PR propose a workaround for this problem, a conditional to define a variable with the flag --openssl-legacy-provider how mentioned here:
https://github.com/webpack/webpack/issues/14532