### PR TITLE
chore: bump azion-framework-adapter to v0.3.1

### DIFF
--- a/webdev/nextjs/config.json
+++ b/webdev/nextjs/config.json
@@ -1,20 +1,8 @@
 {
-    "init": {
-        "cmd": "",
-        "env": "",
-        "output-ctrl": "on-error",
-        "default": ""
-    },
     "build": {
         "cmd": "",
         "env": "./azion/webdev.env",
         "output-ctrl": "on-error",
-        "default": "[[ $(node -v |tr -dc '0-9' | cut -c1-2) -gt 16 ]] && OPENSSL_LEGACY=--openssl-legacy-provider; NODE_OPTIONS=$OPENSSL_LEGACY npx --yes azion-framework-adapter@0.3.0-alpha.0 build --version-id %s --config ./azion/kv.json || exit $?"
-    },
-    "publish": {
-        "pre_cmd": "",
-        "env":"./azion/webdev.env",
-        "output-ctrl": "on-error",
-        "default": "npx --yes azion-framework-adapter@0.2.3 publish --config ./azion/kv.json -t --only-assets --assets-dir ./out || exit $?"
-    }
+        "default": "npx --yes azion-framework-adapter@0.3.1 build --version-id %s || exit $?"
+   }
 }

--- a/webdev/nextjs/kv.json
+++ b/webdev/nextjs/kv.json
@@ -1,7 +1,0 @@
-{
-  "kv": {
-    "bucket": "azion-cells-dev",
-    "region": "us-east-1",
-    "path": "__static_content"
-  }
-}


### PR DESCRIPTION
1) This release contains improvements on error handling so that developer can see Next.js build output in case of failure.
2) The publish step is now handled by azion-cli
3) It's also not necessary anymore to set openssl-legacy provider, because we're not using webpack anymore.